### PR TITLE
Enable Docker Image caching and buildkit for faster CI builds

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,7 @@
+.git
+.gitignore
+.github
+docker-compose.yml
+dist
+Makefile
+README.adoc

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -3,6 +3,10 @@ name: Slides Workflow
 on:
   push:
 
+env:
+  ## Override default value for Docker cached image
+  IMAGE_CACHE_NAME: "dduportal/slides:cicd-lectures"
+
 jobs:
   build:
     name: 'Build Slides'
@@ -10,8 +14,15 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@master
+      - name: 'Login to DockerHub'
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: 'Build'
         run: make build
+      - name: 'Caching for later builds'
+        run: docker push "${IMAGE_CACHE_NAME}"
       - name: 'Verify'
         run: make verify
       - name: 'PDF'

--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -22,6 +22,7 @@ jobs:
       - name: 'Build'
         run: make build
       - name: 'Caching for later builds'
+        if: github.ref == 'refs/heads/main'
         run: docker push "${IMAGE_CACHE_NAME}"
       - name: 'Verify'
         run: make verify

--- a/Makefile
+++ b/Makefile
@@ -20,6 +20,11 @@ endif
 endif
 export PRESENTATION_URL CURRENT_UID REPOSITORY_URL REPOSITORY_BASE_URL
 
+## Docker Buildkit is enabled for faster build and caching of images
+DOCKER_BUILDKIT ?= 1
+COMPOSE_DOCKER_CLI_BUILD ?= 1
+export DOCKER_BUILDKIT COMPOSE_DOCKER_CLI_BUILD
+
 all: clean build verify
 
 # Generate documents inside a container, all *.adoc in parallel

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,14 @@
-version: '2.2'
+version: '2.4'
 
 # Reusable options
 x-slides-base: &slides-base
-  build: ./
-  image: slides-builder
+  build:
+    context: ./
+    cache_from:
+      - ${IMAGE_CACHE_NAME:-slides-builder}
+    args:
+      BUILDKIT_INLINE_CACHE: 1
+  image: ${IMAGE_CACHE_NAME:-slides-builder}
   environment:
     - PRESENTATION_URL=${PRESENTATION_URL}
     - REPOSITORY_URL=${REPOSITORY_URL}


### PR DESCRIPTION
This PR enables Docker's Image Caching to allow faster builds:

- Build context is restricted to its minimum thanks to the `.dockerignore` file
- Docker build now uses the `--from-cache` flag to check DockerHub for cached layers instead of building it when it can (faster operation).
- Buildkit is enabled for both `docker` and `docker-compose` CLIs. Please note that a build argument `BUILDKIT_INLINE_CACHE` is required to ensure a correct usage of the remote layers.
  - Systems with no Buildkit available (older version of Docker for instance) will fall back to the default docker build without failure
- The CI workflow is updated to 
  - Login to the Dockerhub (rate limitation and push allowance) before the build
  - Push the built image right after the build to allow caching update


Build time dropped (in the CI) from ~1m57s (https://github.com/cicd-lectures/slides/runs/1368277445?check_suite_focus=true) to ~25s \o/

Signed-off-by: dduportal <1522731+dduportal@users.noreply.github.com>