### PR TITLE
Tooling simplification

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -45,8 +45,7 @@ serve: clean $(DIST_DIR)
 	@docker-compose up --build --force-recreate serve
 
 shell: $(DIST_DIR)
-	@docker-compose up --build --force-recreate -d wait
-	@docker-compose exec --user root wait sh
+	@CURRENT_UID=0 docker-compose run --entrypoint=sh --rm serve
 
 $(DIST_DIR)/index.html: build
 
@@ -64,6 +63,6 @@ clean:
 	@rm -rf $(DIST_DIR)
 
 qrcode:
-	@docker-compose up --build --force-recreate qrcode
+	@docker-compose run --entrypoint=/app/node_modules/.bin/qrcode --rm serve -t png -o /app/content/images/qrcode.png $(PRESENTATION_URL)
 
 .PHONY: all build verify serve qrcode pdf

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,42 +1,28 @@
 version: '2.4'
 
-# Reusable options
-x-slides-base: &slides-base
-  build:
-    context: ./
-    cache_from:
-      - ${IMAGE_CACHE_NAME:-slides-builder}
-    args:
-      BUILDKIT_INLINE_CACHE: 1
-  image: ${IMAGE_CACHE_NAME:-slides-builder}
-  environment:
-    - PRESENTATION_URL=${PRESENTATION_URL}
-    - REPOSITORY_URL=${REPOSITORY_URL}
-  user: ${CURRENT_UID}
-  volumes:
-    - ./content:/app/content
-    - ./demo:/app/demo
-    - ./dist:/app/dist
-    - ./assets:/app/assets
-    - ./gulp/gulpfile.js:/app/gulpfile.js
-    - ./gulp/tasks:/app/tasks
-    - ./package.json:/app/package.json
-
 services:
-  serve:
-    <<: *slides-base
+  serve: &slides-base
+    build:
+      context: ./
+      cache_from:
+        - ${IMAGE_CACHE_NAME:-slides-builder}
+      args:
+        BUILDKIT_INLINE_CACHE: 1
+    image: ${IMAGE_CACHE_NAME:-slides-builder}
+    environment:
+      - PRESENTATION_URL=${PRESENTATION_URL}
+      - REPOSITORY_URL=${REPOSITORY_URL}
+    user: ${CURRENT_UID}
+    volumes:
+      - ./content:/app/content
+      - ./dist:/app/dist
+      - ./assets:/app/assets
+      - ./gulp/gulpfile.js:/app/gulpfile.js
+      - ./gulp/tasks:/app/tasks
+      - ./package.json:/app/package.json
     ports:
       - "8000:8000"
-
-  wait:
-    <<: *slides-base
-    entrypoint: "sleep 10000"
 
   build:
     <<: *slides-base
     command: "build"
-
-  qrcode:
-    <<: *slides-base
-    entrypoint: /app/node_modules/.bin/qrcode
-    command: -t png -o /app/dist/images/qrcode.png ${PRESENTATION_URL}


### PR DESCRIPTION
BLocked by #2 .

As per our discussions, this PR introduces a slight simplification of the Makefile + docker-compose tooling:

- `docker-compose.yml`: 
  - Removed the services `wait` and `qrcode`
  - Switched to latest version `2.4` of the syntax
  - Used the service `serve` as main YAML anchor
- `Makefile`: use `docker-compose run` for the goals `shell` and `qrcode`. 

Please note that the `make build` goal is kept as a one-shot `docker-compose up` command (instead of being switched to a docker-compose run`), because it requires the flag `--build` to always rebuild the image. It's needed when you're developing to ensure any new node module or new dependency is taken in account straight away.