### PR TITLE
chore(github workflow) switch Docker image cache from DockerHub to GHCR

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -13,7 +13,7 @@ on:
 
 env:
   ## Override default value for Docker cached image
-  IMAGE_CACHE_NAME: "dduportal/slides:cicd-lectures"
+  IMAGE_CACHE_NAME: "ghcr.io/${{ github.actor }}/slides:cicd-lectures"
 
 jobs:
   build:
@@ -22,11 +22,12 @@ jobs:
     steps:
       - name: 'Checkout'
         uses: actions/checkout@master
-      - name: 'Login to DockerHub'
+      - name: Login to GitHub Container Registry
         uses: docker/login-action@v1
         with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: 'Build'
         run: make build
       - name: PDF on main branch


### PR DESCRIPTION
This PR should fix the slide building errors due to authentication failing on DockerHub (I've deleted my token last week 😅)