### PR TITLE
Initialize the 2023 branch

### DIFF
--- a/.github/workflows/build-workflow.yml
+++ b/.github/workflows/build-workflow.yml
@@ -15,7 +15,7 @@ on:
 env:
   ## Override default value for Docker cached image
   IMAGE_CACHE_NAME: "ghcr.io/${{ github.repository_owner }}/slides:cicd-lectures"
-  PRINCIPAL_BRANCH: "2021"
+  PRINCIPAL_BRANCH: "2023"
 
 jobs:
   build-slides:

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ CURRENT_UID = $(shell id -u):$(shell id -g)
 DIST_DIR ?= $(CURDIR)/dist
 
 REPOSITORY_URL = https://github.com/cicd-lectures/slides
-PRESENTATION_URL = https://cicd-lectures.github.io/slides/2021
+PRESENTATION_URL = https://cicd-lectures.github.io/slides/2023
 
 export PRESENTATION_URL CURRENT_UID REPOSITORY_URL
 

--- a/content/chapitres/introduction-to-menuserver.adoc
+++ b/content/chapitres/introduction-to-menuserver.adoc
@@ -30,7 +30,7 @@
 mkdir -p workspace/menu-server && cd workspace/menu-server
 
 # Téléchargez le projet sur votre environnement de développement
-curl -sSLO https://cicd-lectures.github.io/slides/2021/media/menu-server.tar.gz
+curl -sSLO https://cicd-lectures.github.io/slides/2023/media/menu-server.tar.gz
 
 # Décompresser et extraire l'archive téléchargée
 tar xvzf ./menu-server.tar.gz

--- a/content/chapitres/project.adoc
+++ b/content/chapitres/project.adoc
@@ -128,7 +128,7 @@ $ menucli --server-url="https://menu-server-production.herokuapp.com" list-menus
 
 == Critères d’évaluation
 
-* Les critères d’évaluation sont détaillés sur cette page: link:https://docs.google.com/spreadsheets/d/1LJeWM8kCRsi8MKQ7Q7nGCW9znHiGD7hESJvrW6vlyAQ/edit?usp=sharing[Notations ENSG 2021/2022], selon les grandes catégories suivantes :
+* Les critères d’évaluation sont détaillés sur cette page: link:https://docs.google.com/spreadsheets/d/1LJeWM8kCRsi8MKQ7Q7nGCW9znHiGD7hESJvrW6vlyAQ/edit?usp=sharing[Notations ENSG 2022/2023], selon les grandes catégories suivantes :
 ** Git / GitHub  : 4 points
 ** Tests : 2 points
 ** Cycle de vie du projet: 4 points
@@ -137,8 +137,8 @@ $ menucli --server-url="https://menu-server-production.herokuapp.com" list-menus
 
 == Consignes de rendu
 
-* Envoi de l'email pointant vers ces consigne mises à jour le 10 janvier 2022
-* *Deadline du rendu*: 5 semaines à partir du jour de livraison de l'application initiale, soit le 14 février 2022 à midi heure de Paris.
+* Envoi de l'email pointant vers ces consigne
+* *Deadline du rendu*: 5 semaines à partir du jour de livraison de l'application initiale.
 * Vous devrez nous envoyer un mail (par binôme ou trinôme) avec:
 ** Pour chaque membre du binôme / trinôme:
 *** Nom et prénom
@@ -148,7 +148,7 @@ $ menucli --server-url="https://menu-server-production.herokuapp.com" list-menus
 
 == Rendu des notes
 
-* Les notes seront rendues 3 semaines après la deadline, soit pour le 6 mars 2022 au plus tard
+* Les notes seront rendues 3 semaines après la deadline
 * Contestation/relecture : vous aurez ~ 1 semaine après le rendu des notes si jamais vous n'être pas d'accord ou souhaitez une clarification
 
 == Un dernier mot

--- a/content/index.adoc
+++ b/content/index.adoc
@@ -4,7 +4,7 @@
 include::./attributes.adoc[]
 
 [.title]
-ENSG - Décembre 2021
+ENSG - Décembre 2023
 
 [.small]
 * Présentation disponible à l’adresse: {presentationUrl}[{presentationUrl}]


### PR DESCRIPTION
- Bump Docker base images
- Chaotic NPM update run with `ncu -u` (I bet I'll have to remove some of these upgrades, but it's a first blind shot)
- Bump the year and dates (or removes when not clear)