### PR TITLE
chore(gha) ensure that latest stable runner images are specified to avoid warning messages for students

### DIFF
--- a/content/chapitres/ci.adoc
+++ b/content/chapitres/ci.adoc
@@ -97,7 +97,7 @@ Un *Job* est un groupe logique de tâches :
 jobs: # Map de jobs
   build: # 1er job, identifié comme 'build'
     name: 'Build Slides'
-    runs-on: ubuntu-latest # cf. prochaine slide "Concepts de GitHub Actions - Runner"
+    runs-on: ubuntu-22.04 # cf. prochaine slide "Concepts de GitHub Actions - Runner"
     steps: # Collection de steps du job
       - name: 'Build the JAR'
         run: mvn package

--- a/content/code-samples/gh-actions/npm-example.yml
+++ b/content/code-samples/gh-actions/npm-example.yml
@@ -6,13 +6,13 @@ on: # Évènements déclencheurs
     - cron: "*/15 * * * *" # Toutes les 15 minutes
 jobs:
   test-linux:
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-22.04
     steps:
     - uses: actions/checkout@v2
     - run: npm install
     - run: npm test
   test-mac:
-    runs-on: mac-10.15
+    runs-on: macos-12
     steps:
     - uses: actions/checkout@v2
     - run: npm install

--- a/content/code-samples/gh-actions/say-hello-full.yml
+++ b/content/code-samples/gh-actions/say-hello-full.yml
@@ -4,7 +4,7 @@ on:
   - push
 jobs:
   dire_bonjour:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
 # end::common[]
 # tag::container[]
     container:
@@ -34,7 +34,7 @@ jobs:
 # end::run-cowsay[]
 # tag::maven-job[]
   run_maven:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-java@v2


### PR DESCRIPTION
Ref. https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources