### PR TITLE
fix(code-samples) remove GHA depreciation messages by bumping to last major version

### DIFF
--- a/content/code-samples/gh-actions/npm-example.yml
+++ b/content/code-samples/gh-actions/npm-example.yml
@@ -8,12 +8,12 @@ jobs:
   test-linux:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: npm install
     - run: npm test
   test-mac:
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - run: npm install
     - run: npm test

--- a/content/code-samples/gh-actions/say-hello-full.yml
+++ b/content/code-samples/gh-actions/say-hello-full.yml
@@ -18,7 +18,7 @@ jobs:
       - run: echo "Bonjour 👋"
 # end::simple-hello[]
 # tag::checkout[]
-      - uses: actions/checkout@v2 # Récupère le contenu du dépôt correspondant au commit du workflow en cours
+      - uses: actions/checkout@v3 # Récupère le contenu du dépôt correspondant au commit du workflow en cours
 # end::checkout[]
 # tag::show-readme[]
       - run: ls -l # Liste les fichier du répertoire courant
@@ -36,11 +36,11 @@ jobs:
   run_maven:
     runs-on: ubuntu-22.04
     steps:
-      - uses: actions/checkout@v2
-      - uses: actions/setup-java@v2
+      - uses: actions/checkout@v3
+      - uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: '11'
+          java-version: '11content/code-samples'
       - run: mvn -v
       - run: mvn help:effective-pom
 # end::maven-job[]


### PR DESCRIPTION
This (minor) PR removes the following warning from GHA user interface:

<img width="1696" alt="Capture d’écran 2023-02-26 à 15 45 15" src="https://user-images.githubusercontent.com/1522731/221417630-6cc2e07c-4a10-42f8-932b-8ad915ac2def.png">
