### PR TITLE
fix(setup-dev-env) describe gitpod <-> github permission initial setup

### DIFF
--- a/content/chapitres/setup-dev-env.adoc
+++ b/content/chapitres/setup-dev-env.adoc
@@ -68,6 +68,15 @@ image::gitpod-select-editor.png[width=600]
 
 image::gitpod-workspaces.png[width=600]
 
+== Permissions GitPod <-> GitHub 🔐
+
+* Pour les besoins de ce cours, vous devez autoriser GitPod à pouvoir effectuer certaines modification dans vos dépôts GitHub
+* Rendez-vous sur https://gitpod.io/user/integrations[la page des intégrations avec GitPod,window="_blank"]
+* Éditez les permissions de la ligne "GitHub" (les 3 petits points à droits) et sélectionnez uniquement :
+** `user:email`
+** `public_repo`
+** `workflow`
+
 == Démarrer l'environnement GitPod
 
 Cliquez sur le bouton ci-dessous pour démarrer un environnement GitPod personnalisé:


### PR DESCRIPTION
This PR adds a slide describing how to setup the initial GitPod environment to avoid errors later when `git push`-ing from the GitPod workspaces.

Ref. #90