### PR TITLE
fix(revealjs-asciidoctor) correct missing syntax color from code snippets

### DIFF
--- a/content/attributes.adoc
+++ b/content/attributes.adoc
@@ -15,8 +15,6 @@
 :revealjs_controls: true
 :experimental: true
 :source-highlighter: highlightjs
-:highlightjs-main-theme: github
-:highlightjs-theme: {revealjsdir}/plugin/highlight/styles/{highlightjs-main-theme}.min.css
 :invert: state=invert,background-color="rgb(248, 228, 130)"
 :stylesdir: styles
 :notitle: true

--- a/gulp/tasks/prepare-dependencies.js
+++ b/gulp/tasks/prepare-dependencies.js
@@ -14,6 +14,8 @@ module.exports = function (gulp, plugins, current_config) {
                 .pipe(gulp.dest(revealJsDestDir + '/js/')),
             zenBurnCss = gulp.src(baseRevealJSPath + '/lib/css/zenburn.css')
                 .pipe(gulp.dest(revealJsDestDir + '/lib/css/')),
+            monokaiCss = gulp.src(baseRevealJSPath + '/lib/css/monokai.css')
+                .pipe(gulp.dest(revealJsDestDir + '/lib/css/')),
             notesJs = gulp.src(baseRevealJSPath + '/plugin/notes/notes.js')
                 .pipe(gulp.dest(revealJsDestDir + '/plugin/notes/')),
             markedJs = gulp.src(baseRevealJSPath + '/plugin/markdown/marked.js')
@@ -28,6 +30,7 @@ module.exports = function (gulp, plugins, current_config) {
             paperCSS,
             mainRevealJs,
             zenBurnCss,
+            monokaiCss,
             notesJs,
             notesHtml,
             zoomJs,


### PR DESCRIPTION
This PR fixes the missing code snippet syntax color.

It was broken by #80 : the `github` stylesheet is no longer present (at least not in the current `highlightjs` distribution and version we use today).

The fix is easy: Fallback to the default CSS style (`monokai`)