### PR TITLE
chore(content): bump referenced actions to up to date versions

### DIFF
--- a/content/code-samples/gh-actions/menu-server.yml
+++ b/content/code-samples/gh-actions/menu-server.yml
@@ -10,8 +10,6 @@ jobs:
     steps:
       - name: Checkout Code
         uses: actions/checkout@v4
-      - name: Checkout Code
-        uses: actions/checkout@v4
       - name: Setup JDK Zulu 17
         uses: actions/setup-java@v4
         with:

--- a/content/code-samples/gh-actions/menu-server.yml
+++ b/content/code-samples/gh-actions/menu-server.yml
@@ -9,16 +9,16 @@ jobs:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup JDK Zulu 17
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'zulu'
           java-version: '17'
       - name: Setup Maven 3.9.0
-        uses: stCarolas/setup-maven@v4.5
+        uses: stCarolas/setup-maven@v5
         with:
           maven-version: 3.9.0
       - name: Check Maven tooling

--- a/content/code-samples/gh-actions/npm-example.yml
+++ b/content/code-samples/gh-actions/npm-example.yml
@@ -8,12 +8,12 @@ jobs:
   test-linux:
     runs-on: ubuntu-22.04
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: npm install
     - run: npm test
   test-mac:
     runs-on: macos-12
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - run: npm install
     - run: npm test

--- a/content/code-samples/gh-actions/say-hello-full.yml
+++ b/content/code-samples/gh-actions/say-hello-full.yml
@@ -18,7 +18,7 @@ jobs:
       - run: echo "Bonjour 👋"
 # end::simple-hello[]
 # tag::checkout[]
-      - uses: actions/checkout@v3 # Récupère le contenu du dépôt correspondant au commit du workflow en cours
+      - uses: actions/checkout@v4 # Récupère le contenu du dépôt correspondant au commit du workflow en cours
 # end::checkout[]
 # tag::show-readme[]
       - run: ls -l # Liste les fichier du répertoire courant


### PR DESCRIPTION
### What does this PR do?

This PR bumps the referenced GitHub actions to updated versions

- checkout goes to v4
- setup-java goes to v4
- setup-maven goes to v5

Fixes #129